### PR TITLE
Add support for PHP filetype

### DIFF
--- a/autoload/ctrlp/funky/php.vim
+++ b/autoload/ctrlp/funky/php.vim
@@ -4,7 +4,7 @@
 " License: The MIT License
 
 let s:filter = [{ 'pattern': '\v\s*function\s+\w.+\s*\(',
-                \ 'filter': []}
+                \ 'filter': ['\m\C^[\t ]*', '', '']}
                 \ ]
 
 function! ctrlp#funky#php#apply_filter(bufnr)


### PR DESCRIPTION
Here's a go at a PHP syntax file. It uses the same function signature as the primary one from the JS file, since that will match PHP functions even inside classes.
