### PR TITLE
Add filter for 'html' filetype

### DIFF
--- a/autoload/ctrlp/funky/html.vim
+++ b/autoload/ctrlp/funky/html.vim
@@ -1,0 +1,11 @@
+" Language: HTML (html)
+" Author: mmazer 
+" License: The MIT License
+
+function! ctrlp#funky#html#filters()
+  let filters = [
+        \ { 'pattern': '\v<id>\=',
+        \   'formatter': ['\m\C^[\t ]*', '', ''] }
+  \ ]
+  return filters
+endfunction


### PR DESCRIPTION
This adds a basic filter for 'html' filetypes that matches elements with an 'id' attribute.
