### PR TITLE
Non-greedy multiline regex for functions

### DIFF
--- a/autoload/ctrlp/funky/python.vim
+++ b/autoload/ctrlp/funky/python.vim
@@ -4,9 +4,7 @@
 
 function! ctrlp#funky#python#filters()
   let filters = [
-        \ { 'pattern': '\v\C^\s*class\s+\w+\s*(\([^\)]+\))?:',
-        \   'formatter': ['\v\C^\s*', '', ''] },
-        \ { 'pattern': '\v\C^\s*def\s+\w+\s*(\_.*):',
+        \ { 'pattern': '\v\C^\s*(class\s+\w+\s*(\([^\)]+\))?|def\s+\w+\s*(\_.{-})):',
         \   'formatter': ['\v\C^\s*', '', ''] }
   \ ]
   return filters


### PR DESCRIPTION
Make the regex faster while keeping multiline support.

Tested by @tacahiroy

```
10,000 lines:
    Current regex:
        15.352472
    Improved regex (by @dusans):
        0.240578
```
