### PR TITLE
change php function matching regex

### DIFF
--- a/autoload/ctrlp/funky/php.vim
+++ b/autoload/ctrlp/funky/php.vim
@@ -4,7 +4,7 @@
 
 function! ctrlp#funky#php#filters()
   let filters = [
-        \ { 'pattern': '\v\s*function\s+\w.+\s*\(',
+        \ { 'pattern': '\v^\s*\w*\s*function\s+[&]*\w+\s*\(',
         \   'formatter': ['\m\C^[\t ]*', '', ''] }
   \ ]
 


### PR DESCRIPTION
original php function regex can not match below
1. function &getName()
but take " # {{{ function getName" as a function def which is a vim fold maker and description.
