### PR TITLE
Objective-C message return type may contain spaces

### DIFF
--- a/autoload/ctrlp/funky/objc.vim
+++ b/autoload/ctrlp/funky/objc.vim
@@ -4,7 +4,7 @@
 
 function! ctrlp#funky#objc#filters()
   let filters = [
-        \ { 'pattern': '\m\C^\(-\|+\)\s*(\S\+)\s*.*',
+        \ { 'pattern': '\m\C^\(-\|+\)\s*([a-zA-Z0-9 *]\+)\s*.*',
         \   'formatter': [] }
   \ ]
 


### PR DESCRIPTION
The parser misses lines of objective-c code that look like: `- (NSObject *)method;` Return type can actually contain spaces. Instead of using `.*` pattern to include the space I decided to narrow the group down for a little bit faster matching.
