### PR TITLE
Modify php regex to consider additional keywords

### DIFF
--- a/autoload/ctrlp/funky/php.vim
+++ b/autoload/ctrlp/funky/php.vim
@@ -4,7 +4,7 @@
 
 function! ctrlp#funky#php#filters()
   let filters = [
-        \ { 'pattern': '\v^\s*\w*\s*function\s+[&]*\w+\s*\(',
+        \ { 'pattern': '\v^\s*\w*(\s*\w*)\s*function\s+[&]*\w+\s*\(',
         \   'formatter': ['\m\C^[\t ]*', '', ''] }
   \ ]
 


### PR DESCRIPTION
The modification allows ctrlp-funky to consider additional 
function keywords (i.e. final, static) when matching php function signatures.
