### PR TITLE
PHP pattern updated to match static methods.

### DIFF
--- a/autoload/ctrlp/funky/php.vim
+++ b/autoload/ctrlp/funky/php.vim
@@ -4,7 +4,7 @@
 
 function! ctrlp#funky#php#filters()
   let filters = [
-        \ { 'pattern': '\v^\s*\w*\s*function\s+[&]*\w+\s*\(',
+        \ { 'pattern': '\v^(\s|public|static)*function\s+[&]*\w+\s*\(',
         \   'formatter': ['\m\C^[\t ]*', '', ''] }
   \ ]
 


### PR DESCRIPTION
I noticed that CtrlP Funky was not finding any methods in a static class because the original pattern, `\s*\w*\s*function` won't match "public static function" (for example).

I've updated the pattern to match these cases.
