### PR TITLE
typescript support for functions, constructors and exported vars

### DIFF
--- a/autoload/ctrlp/funky/ft/typescript.vim
+++ b/autoload/ctrlp/funky/ft/typescript.vim
@@ -3,9 +3,15 @@
 " License: The MIT License
 
 function! ctrlp#funky#ft#typescript#filters()
- let filters = [
-        \ { 'pattern': '\v\s*((module)|(class)|(interface)|(enum))\s+\w+.*\{',
-        \   'formatter': [] }
+  let filters = [
+      \ { 'pattern': '\v^[ \t]*(export)?[ \t]*((module)|(class)|(interface)|(enum)|(function))[ \t]+([a-zA-Z0-9_]+)',
+      \   'formatter': []},
+      \ { 'pattern': '\v^[ \t]*export[ \t]+var[ \t]+([a-zA-Z0-9_]+)',
+      \   'formatter': []},
+      \ { 'pattern': '\v^[ \t]*(export)?[ \t]*(public|private|protected)[ \t]+(static)?[ \t]*([a-zA-Z0-9_]+)',
+      \   'formatter': []},
+      \ { 'pattern': '\v^[ \t]*(constructor)[ \t]*',
+      \   'formatter': []},
   \ ]
   return filters
 endfunction


### PR DESCRIPTION
Added more support for typescript which includes functions, constructors, exported vars and member variables.

**Without the patch:**
![image](https://cloud.githubusercontent.com/assets/287744/6887621/d813a502-d619-11e4-8cbe-ca73f3f7151a.png)

**With the patch:**
(For now the fullName type function will not work. You need to at least have private/public/protected)
![image](https://cloud.githubusercontent.com/assets/287744/6887598/38d3f488-d619-11e4-87ae-114077b6845a.png)
