### PR TITLE
Add support for rspec definitions

### DIFF
--- a/autoload/ctrlp/funky/ft/ruby.vim
+++ b/autoload/ctrlp/funky/ft/ruby.vim
@@ -36,6 +36,13 @@ function! ctrlp#funky#ft#ruby#filters()
     \ )
   endif
 
+  if get(g:, 'ctrlp_funky_ruby_rspec', 1)
+    call extend(filters, [
+          \ { 'pattern': '\m\C^[\t ]*\(describe\|context\|feature\|scenario\|it\)[\t ]\+\S\+',
+          \   'formatter': [] }]
+    \ )
+  endif
+
   if get(g:, 'ctrlp_funky_ruby_rake_words', 1)
     call extend(filters, [
           \ { 'pattern': '\m\C^[\t ]*task[\t ]\+\S\+',

--- a/doc/ctrlp-funky.txt
+++ b/doc/ctrlp-funky.txt
@@ -300,7 +300,16 @@ Set this to 1 (enabled) and the result will include access modifiers such as
 (default: 1)
 (value: 0 or 1)
 >
-	let g:ctrlp_funky_ruby_chef_words = 1
+	let g:ctrlp_funky_ruby_access = 1
+<
+
+					*'g:ctrlp_funky_ruby_rspec'*
+Set this to 1 (enabled) and the result will include rspec definitions like
+'context', 'scenario', 'feature', 'describe' and 'it'.
+(default: 1)
+(value: 0 or 1)
+>
+	let g:ctrlp_funky_ruby_rspec = 1
 <
 
 [sh]					*ctrlp-funky-sh*


### PR DESCRIPTION
Added basic support for rspec definitions so ruby devs can easily jump to test definitions in spec files.