### PR TITLE
add support for ES6 shorthand function declaration in object literals

### DIFF
--- a/autoload/ctrlp/funky/ft/javascript.vim
+++ b/autoload/ctrlp/funky/ft/javascript.vim
@@ -4,9 +4,11 @@
 
 function! ctrlp#funky#ft#javascript#filters()
   let filters = [
+        \ { 'pattern': '\v\w+\s*\(.*\)\s*\{',
+        \   'formatter': ['\v(^\s*)|(\s*\{.*\ze \t#)', '', 'g'] },
         \ { 'pattern': '\v\s*function\s+\w+\s*\(',
         \   'formatter': ['\v(^\s*)|(\s*\{.*\ze \t#)', '', 'g'] },
-        \ { 'pattern': '\v\w.+\:\s*function\s*\(', 
+        \ { 'pattern': '\v\w.+\:\s*function\s*\(',
         \   'formatter': ['\v(^\s*)|(\s*\{.*\ze \t#)', '', 'g'] },
         \ { 'pattern': '\v\C\w.+\s*\=\s*function\s*\(',
         \   'formatter': ['\v(^\s*)|(\s*\{.*\ze \t#)', '', 'g'] },


### PR DESCRIPTION
Adds support for ES6 JavaScript style of function/method declaration:

```javascript
const a = {
    func1(p1, p2) {
    }
}
```