### PR TITLE
add support for proto

### DIFF
--- a/autoload/ctrlp/funky/ft/proto.vim
+++ b/autoload/ctrlp/funky/ft/proto.vim
@@ -1,0 +1,13 @@
+" Language: Proto
+" Author: timfeirg
+" License: The MIT License
+
+function! ctrlp#funky#ft#proto#filters()
+  let filters = [
+        \ { 'pattern': '\m\C^[\t ]*message[\t ]\+',
+        \   'formatter': [] },
+        \ { 'pattern': '\m\C^[\t ]*service[\t ]\+',
+        \   'formatter': [] },
+  \ ]
+  return filters
+endfunction


### PR DESCRIPTION
add support for [proto](https://developers.google.com/protocol-buffers/docs/overview)

I copied some code from `ft/go.vim` (authored by Takahiro Yoshihara) and changed the keywords, but it's working.

the biggest challenge here is writing the author name, should I change it to Takahiro Yoshihara?