### PR TITLE
Global Nudist Mode && New Filetype: SQL

### DIFF
--- a/autoload/ctrlp/funky.vim
+++ b/autoload/ctrlp/funky.vim
@@ -436,7 +436,7 @@ function! ctrlp#funky#clear_cache_all()
 endfunction
 
 function! s:is_nudist(ft)
-  return index(s:nudists, a:ft) >= 0
+  return get(g:, 'ctrlp_funky_nudist_mode', 0) || index(s:nudists, a:ft) >= 0
 endfunction
 
 function! s:be_naked(lines, strippers)

--- a/autoload/ctrlp/funky/ft/sql.vim
+++ b/autoload/ctrlp/funky/ft/sql.vim
@@ -1,0 +1,21 @@
+" Language: SQL
+" Author: somini
+" License: The MIT License
+
+let s:pattern = '\V\c\<function\>\W\+\w\+(\_.\{-})'
+let s:function_name = '\V\cfunction\s\+\(\k\+\)'
+
+function! ctrlp#funky#ft#sql#filters()
+  " By default, remove whitespace and arguments
+  return [{
+        \ 'pattern': s:pattern,
+        \ 'formatter': ['\V\c\^\s\+\|\%((\.\*\$\)', '', 'g']
+        \ }]
+endfunction
+
+function! ctrlp#funky#ft#sql#strippers()
+  return [{
+        \ 'pattern': s:function_name,
+        \ 'position': 1,
+        \ }]
+endfunction

--- a/doc/ctrlp-funky.txt
+++ b/doc/ctrlp-funky.txt
@@ -191,12 +191,20 @@ not scrollable = limit mode.
 <
 
 					*'g:ctrlp_funky_nudists'*
+					*'g:ctrlp_funky_nudist_mode'*
 Some filetypes support nudist mode that allows you to find quickly a function you want.
 If the filetype is contained in this variable you may see just function name in ctrlp window.
 (default: undef)
 (value: List)
 >
 	let g:ctrlp_funky_nudists = [ 'php' ]
+<
+
+You can also setup nudist mode for all avaliable filetypes by using the
+following variable
+(default: 0)
+>
+	let g:ctrlp_funky_nudist_mode = 1
 <
 
 ==============================================================================


### PR DESCRIPTION
This PR mixes up two things, I'm sorry but I was too lazy to split them into two different branches.

The first is global nudist mode. Add another option to enable nudist mode for all available filetypes, instead of defining one by one.

The second is support for PL/SQL filetype. I tested on Oracle dialects, but I think it should work on others too.