### PR TITLE
User removed in Thanks section because is duplicated.

### DIFF
--- a/doc/ctrlp-funky.txt
+++ b/doc/ctrlp-funky.txt
@@ -412,7 +412,6 @@ THANKS						*ctrlp-funky-thanks*
   * *svenwin*         <github.com/svenwin>
   * *anstosa*         <github.com/anstosa>
   * *imran-uk*        <github.com/imran-uk>
-  * *timfeirg*        <github.com/timfeirg>
 
 
 ==============================================================================


### PR DESCRIPTION
This cause problems when Vundle has updated because helptags return errors. 