### PR TITLE
Add missing rust support to document

### DIFF
--- a/doc/ctrlp-funky.txt
+++ b/doc/ctrlp-funky.txt
@@ -53,6 +53,7 @@ Currently, |ctrlp-funky| supports following file types:
 * proto (Protocol Buffers)
 * python
 * ruby (ruby, rake, rspec and chef recipe)
+* rust
 * scala
 * sh (bash, dash and zsh)
 * sql


### PR DESCRIPTION
ctrlp-funky seems to support the rust filetype: https://github.com/tacahiroy/ctrlp-funky/blob/master/autoload/ctrlp/funky/ft/rust.vim