### PR TITLE
Add private method pattern to elixir

### DIFF
--- a/autoload/ctrlp/funky/ft/elixir.vim
+++ b/autoload/ctrlp/funky/ft/elixir.vim
@@ -5,6 +5,8 @@
 function! ctrlp#funky#ft#elixir#filters()
   let filters = [
         \ { 'pattern': '\m\C^[\t ]*def[\t ]\+\S\+.*do[\t ]*$',
+        \   'formatter': []},
+        \ { 'pattern': '\m\C^[\t ]*defp[\t ]\+\S\+.*do[\t ]*$',
         \   'formatter': []}
   \ ]
   return filters

--- a/autoload/ctrlp/funky/ft/elixir.vim
+++ b/autoload/ctrlp/funky/ft/elixir.vim
@@ -4,10 +4,8 @@
 
 function! ctrlp#funky#ft#elixir#filters()
   let filters = [
-        \ { 'pattern': '\m\C^[\t ]*def[\t ]\+\S\+.*do[\t ]*$',
+        \ { 'pattern': '\m\C^[\t ]*def\(p\|macro\)\?[\t ]\+\S\+.*do[\t ]*$',
         \   'formatter': []},
-        \ { 'pattern': '\m\C^[\t ]*defp[\t ]\+\S\+.*do[\t ]*$',
-        \   'formatter': []}
   \ ]
   return filters
 endfunction


### PR DESCRIPTION
Elixir has a `defp` variant of defining methods which are private. This change adds the pattern.