### PR TITLE
Allow named anonymous functions on javascript

### DIFF
--- a/autoload/ctrlp/funky/ft/javascript.vim
+++ b/autoload/ctrlp/funky/ft/javascript.vim
@@ -4,6 +4,8 @@
 
 function! ctrlp#funky#ft#javascript#filters()
   let filters = [
+        \ { 'pattern': '\v\S+\s+\=\s+(\(?\S+.*\)?|\(\))\s+\=\>',
+        \   'formatter': ['\v(^\s*(const|let|var)\s*)|(\s*\{.*\ze \t#)', '', 'g'] },
         \ { 'pattern': '\v\w+\s*\(.*\)\s*\{',
         \   'formatter': ['\v(^\s*)|(\s*\{.*\ze \t#)', '', 'g'] },
         \ { 'pattern': '\v\s*function\s+\w+\s*\(',


### PR DESCRIPTION
This finds the javascript functions that are defined using the anonymous function style.

For example,

```
const someFunction = () => {
  // ...
}
```

or

```
var ReactComponent = props => <span>{props.children}</span>;
```

or even

```
const a = {};

a.dummyFunc = () => {}
```