### PR TITLE
Add support for ExUnit tests

### DIFF
--- a/autoload/ctrlp/funky/ft/elixir.vim
+++ b/autoload/ctrlp/funky/ft/elixir.vim
@@ -4,10 +4,8 @@
 
 function! ctrlp#funky#ft#elixir#filters()
   let filters = [
-        \ { 'pattern': '\m\C^[\t ]*def\(p\|macro\)\?[\t ]\+\S\+.*do[\t ]*$',
-        \   'formatter': []},
-        \ { 'pattern': '\m\C^[\t ]*\(describe\|test\)[\t ]\+\S\+.*do[\t ]*$',
-        \   'formatter': [] }
+        \ { 'pattern': '\m\C^[\t ]*\(def\(p\|macro\)\|describe\|test\)\?[\t ]\+\S\+.*do[\t ]*$',
+        \   'formatter': []}
   \ ]
   return filters
 endfunction

--- a/autoload/ctrlp/funky/ft/elixir.vim
+++ b/autoload/ctrlp/funky/ft/elixir.vim
@@ -1,11 +1,13 @@
 " Language: elixir
-" Author: Takahiro Yoshihara
+" Author: Takahiro Yoshihara, Jagtesh Chadha, Hasitha Pathiraja
 " License: The MIT License
 
 function! ctrlp#funky#ft#elixir#filters()
   let filters = [
         \ { 'pattern': '\m\C^[\t ]*def\(p\|macro\)\?[\t ]\+\S\+.*do[\t ]*$',
         \   'formatter': []},
+        \ { 'pattern': '\m\C^[\t ]*\(describe\|test\)[\t ]\+\S\+.*do[\t ]*$',
+        \   'formatter': [] }
   \ ]
   return filters
 endfunction


### PR DESCRIPTION
This allows for matching `describe` and `test` blocks in ExUnit tests.