### PR TITLE
add support for thrift IDL

### DIFF
--- a/autoload/ctrlp/funky/ft/thrift.vim
+++ b/autoload/ctrlp/funky/ft/thrift.vim
@@ -1,0 +1,11 @@
+" Language: Thrift
+" Author: timfeirg
+" License: The MIT License
+
+function! ctrlp#funky#ft#thrift#filters()
+  let filters = [
+        \ { 'pattern': '\m\C^[\t ]*\(struct\|service\)[\t ]\+',
+        \   'formatter': [] },
+  \ ]
+  return filters
+endfunction

--- a/doc/ctrlp-funky.txt
+++ b/doc/ctrlp-funky.txt
@@ -59,6 +59,7 @@ Currently, |ctrlp-funky| supports following file types:
 * sh (bash, dash and zsh)
 * sql
 * tex (LaTeX)
+* thrift
 * typescript
 * vb (Visual Basic)
 * vim


### PR DESCRIPTION
it's mostly copied from proto.vim, but it works.