### PR TITLE
improve regex filters for golang

### DIFF
--- a/autoload/ctrlp/funky/ft/go.vim
+++ b/autoload/ctrlp/funky/ft/go.vim
@@ -7,11 +7,13 @@ function! ctrlp#funky#ft#go#filters()
   let filters = [
         \ { 'pattern': '\m\C^[\t ]*func[\t ]\+',
         \   'formatter': [] },
+        \ { 'pattern': '\m\C^\s*\w\+\s\+\(struct\|interface\)[\t {]\+',
+        \   'formatter': [] },
   \ ]
 
   if get(g:, 'ctrlp_funky_go_types', 1)
     call extend(filters, [
-          \ { 'pattern': '\m\C^[\t ]*type[\t ]\+',
+          \ { 'pattern': '\m\C^[\t ]*type[\t ]\+\w',
           \   'formatter': [] }]
     \ )
   endif


### PR DESCRIPTION
when using the following struct/interface declaration style:

```golang
type (
    App struct {}
)
```

the actual struct/interface definition doesn't get matched by ctrlp-funky, but rather a single line containing `type (`, as shown in the screenshot:

![image](https://user-images.githubusercontent.com/4319104/39392650-456c60ae-4aec-11e8-8b9f-7a025d1e9eb6.png)

which looks like this using this PR:

![image](https://user-images.githubusercontent.com/4319104/39392664-7e189936-4aec-11e8-8dd8-6abac8261b7d.png)
