### PR TITLE
Does not trigger autocommands when opening the funky window

### DIFF
--- a/autoload/ctrlp/funky.vim
+++ b/autoload/ctrlp/funky.vim
@@ -229,7 +229,7 @@ function! ctrlp#funky#init(bufnr)
     let &eventignore = 'BufLeave'
 
     let ctrlp_winnr = bufwinnr(bufnr(''))
-    execute bufwinnr(a:bufnr) . 'wincmd w'
+    noautocmd execute bufwinnr(a:bufnr) . 'wincmd w'
     let pos = getpos('.')
 
     " TODO: Need to fix priority for options
@@ -244,11 +244,11 @@ function! ctrlp#funky#init(bufnr)
     let candidates = ctrlp#funky#candidates(bufs)
 
     " activate the former buffer
-    execute 'buffer ' . bufname(a:bufnr)
+    noautocmd execute 'buffer ' . bufname(a:bufnr)
     call setpos('.', pos)
     let filetype = s:filetype(a:bufnr)
 
-    execute ctrlp_winnr . 'wincmd w'
+    noautocmd execute ctrlp_winnr . 'wincmd w'
     if len(bufs) == 1 | call s:syntax(filetype) | endif
 
     return candidates


### PR DESCRIPTION
During initialization, there is a going back and forth between buffers/windows which triggers autocommands. This causes problems such as [this](https://github.com/blueyed/vim-diminactive/issues/14). This PR adds `noautocmd` to a couple of lines.