### PR TITLE
Support Elixir function definition spanning into multiple line

### DIFF
--- a/autoload/ctrlp/funky/ft/elixir.vim
+++ b/autoload/ctrlp/funky/ft/elixir.vim
@@ -4,7 +4,7 @@
 
 function! ctrlp#funky#ft#elixir#filters()
   let filters = [
-        \ { 'pattern': '\m\C^[\t ]*\(def\|defp\|defmacro\|describe\|test\)[\t ]\+\S\+.*do[\t ]*$',
+        \ { 'pattern': '\m\C^[\t ]*\(def\|defp\|defmacro\|describe\|test\)[\t ]\+\S\+\_.*do[\t ]*$',
         \   'formatter': []}
   \ ]
   return filters


### PR DESCRIPTION
This following function `valid_row?` (which is formatted automatically by `mix`) is not included in funky.

```elixir
defmodule M do
  def valid_row?(
        %{
          "PHONE" => phone,
          "TOTAL" => total,
          "STATUS" => status
        } = _row
      ) do
    String.length(phone) >= 10 &&
      total > 1000 &&
      status == 'DONE'
  end
end
```

Replacing `\.` with `\_.` to match any single character including newline, this will include the above function.

Please help to review it. Thanks.
