### PR TITLE
Add Terraform support

### DIFF
--- a/autoload/ctrlp/funky/ft/terraform.vim
+++ b/autoload/ctrlp/funky/ft/terraform.vim
@@ -1,0 +1,7 @@
+" Language: Terraform (HCL)
+" Author: YOSHIHARA Takahiro
+" License: The MIT License
+
+function! ctrlp#funky#ft#terraform#filters()
+  return ctrlp#funky#ft#tf#filters()
+endfunction


### PR DESCRIPTION
The `terraform` file type is actually set by hashivim/vim-terraform plugin.